### PR TITLE
feat: normalize locale aliases across intl formatters

### DIFF
--- a/src/Formatter/Intl/IntlFormatterBridge.php
+++ b/src/Formatter/Intl/IntlFormatterBridge.php
@@ -5,6 +5,7 @@ namespace Rjds\PhpHumanize\Formatter\Intl;
 use DateTimeInterface;
 use DateTimeZone;
 use IntlDateFormatter;
+use Rjds\PhpHumanize\Locale\LocaleNormalizer;
 
 final class IntlFormatterBridge
 {
@@ -38,12 +39,7 @@ final class IntlFormatterBridge
 
     private static function normalizeLocale(string $locale): string
     {
-        $normalized = trim($locale);
-        if ($normalized === '') {
-            return 'en';
-        }
-
-        return $normalized;
+        return LocaleNormalizer::normalizeOrDefault($locale, 'en');
     }
 
     private static function normalizeTimezone(string $timezone): string

--- a/src/HumanizerConfig.php
+++ b/src/HumanizerConfig.php
@@ -3,6 +3,7 @@
 namespace Rjds\PhpHumanize;
 
 use InvalidArgumentException;
+use Rjds\PhpHumanize\Locale\LocaleNormalizer;
 
 final class HumanizerConfig
 {
@@ -17,7 +18,7 @@ final class HumanizerConfig
         private string $listConjunction = self::DEFAULT_LIST_CONJUNCTION,
         private string $truncateSuffix = self::DEFAULT_TRUNCATE_SUFFIX,
     ) {
-        $this->locale = self::normalizeRequiredString($this->locale, 'locale');
+        $this->locale = LocaleNormalizer::normalizeRequired($this->locale, 'locale');
         $this->numberPrecision = self::normalizePrecision($this->numberPrecision);
         $this->listConjunction = self::normalizeRequiredString($this->listConjunction, 'listConjunction');
     }

--- a/src/Locale/LocaleNormalizer.php
+++ b/src/Locale/LocaleNormalizer.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Rjds\PhpHumanize\Locale;
+
+use InvalidArgumentException;
+
+final class LocaleNormalizer
+{
+    public static function normalize(string $locale): string
+    {
+        $normalized = trim($locale);
+        $normalized = str_replace('_', '-', $normalized);
+        $collapsed = preg_replace('/-+/', '-', $normalized);
+        $normalized = $collapsed ?? '';
+        $parts = explode('-', $normalized);
+
+        foreach ($parts as $index => $part) {
+            if ($part === '') {
+                $parts[$index] = '';
+            } elseif ($index === 0) {
+                $parts[$index] = strtolower($part);
+            } elseif (self::isScriptCode($part)) {
+                $parts[$index] = ucfirst(strtolower($part));
+            } elseif (self::isRegionCode($part)) {
+                $parts[$index] = strtoupper($part);
+            } else {
+                $parts[$index] = strtolower($part);
+            }
+        }
+
+        return implode('-', $parts);
+    }
+
+    public static function normalizeOrDefault(string $locale, string $defaultLocale = 'en'): string
+    {
+        $normalized = self::normalize($locale);
+        if ($normalized !== '') {
+            return $normalized;
+        }
+
+        $fallback = self::normalize($defaultLocale);
+        return $fallback !== '' ? $fallback : 'en';
+    }
+
+    public static function normalizeRequired(string $locale, string $field = 'locale'): string
+    {
+        $normalized = self::normalize($locale);
+        if ($normalized === '') {
+            throw new InvalidArgumentException(sprintf('%s cannot be empty.', $field));
+        }
+
+        return $normalized;
+    }
+
+    private static function isScriptCode(string $part): bool
+    {
+        return strlen($part) === 4 && ctype_alpha($part);
+    }
+
+    private static function isRegionCode(string $part): bool
+    {
+        return strlen($part) === 2 && ctype_alpha($part);
+    }
+}

--- a/tests/Formatter/DateTime/DateFormatterTest.php
+++ b/tests/Formatter/DateTime/DateFormatterTest.php
@@ -28,6 +28,11 @@ class DateFormatterTest extends TestCase
                 'Donderdag 17 februari 2022'
             ],
             'dutch locale with region' => ['2026-03-30 12:00:00+00:00', 'nl_NL', 'Maandag 30 maart 2026'],
+            'dutch locale alias with hyphen and mixed case' => [
+                '2026-03-30 12:00:00+00:00',
+                'NL-nl',
+                'Maandag 30 maart 2026'
+            ],
             'dutch uppercase locale' => ['2026-03-30 12:00:00+00:00', 'NL', 'Maandag 30 maart 2026'],
             'english leap day' => [
                 '2024-02-29 12:00:00+00:00',

--- a/tests/Formatter/Intl/IntlFormatterBridgeTest.php
+++ b/tests/Formatter/Intl/IntlFormatterBridgeTest.php
@@ -73,9 +73,9 @@ class IntlFormatterBridgeTest extends TestCase
         self::assertSame('en', $this->invokePrivate('normalizeLocale', '   '));
     }
 
-    public function testNormalizeLocaleKeepsUnderscoreLocale(): void
+    public function testNormalizeLocaleCanonicalizesLocaleAlias(): void
     {
-        self::assertSame('nl_NL', $this->invokePrivate('normalizeLocale', 'nl_NL'));
+        self::assertSame('nl-NL', $this->invokePrivate('normalizeLocale', 'nl_NL'));
     }
 
     public function testNormalizeTimezoneReturnsUtcForSignedOffset(): void
@@ -135,7 +135,7 @@ class IntlFormatterBridgeTest extends TestCase
                 parent::__construct($dateTime);
             }
 
-            public function getTimezone(): DateTimeZone|false
+            public function getTimezone(): DateTimeZone
             {
                 return $this->timezone;
             }

--- a/tests/Formatter/Number/NumberFormatterTest.php
+++ b/tests/Formatter/Number/NumberFormatterTest.php
@@ -24,6 +24,7 @@ class NumberFormatterTest extends TestCase
         return [
             'english default separators' => [1234567.89, 2, 'en', '1,234,567.89'],
             'english locale with region' => [1234.5, 1, 'en_US', '1,234.5'],
+            'english locale alias with hyphen and mixed case' => [1234.5, 1, 'EN-us', '1,234.5'],
             'dutch separators' => [1234567.89, 2, 'nl', '1.234.567,89'],
             'dutch locale with region' => [1234.5, 1, 'nl_NL', '1.234,5'],
             'dutch uppercase locale' => [1234.5, 1, 'NL', '1.234,5'],

--- a/tests/HumanizerConfigTest.php
+++ b/tests/HumanizerConfigTest.php
@@ -40,6 +40,21 @@ class HumanizerConfigTest extends TestCase
         self::assertSame('...', $updated->getTruncateSuffix());
     }
 
+    public function testItNormalizesLocaleAliases(): void
+    {
+        $config = new HumanizerConfig(locale: ' EN_us ');
+
+        self::assertSame('en-US', $config->getLocale());
+        self::assertSame('nl-NL', $config->withLocale('nl_nl')->getLocale());
+    }
+
+    public function testItTrimsListConjunction(): void
+    {
+        $config = new HumanizerConfig(listConjunction: '  or  ');
+
+        self::assertSame('or', $config->getListConjunction());
+    }
+
     public function testItRejectsEmptyLocale(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Locale/LocaleNormalizerTest.php
+++ b/tests/Locale/LocaleNormalizerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Rjds\PhpHumanize\Tests\Locale;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Rjds\PhpHumanize\Locale\LocaleNormalizer;
+
+class LocaleNormalizerTest extends TestCase
+{
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function normalizeProvider(): array
+    {
+        return [
+            'trims and lowercases language' => [' EN ', 'en'],
+            'converts underscore and uppercases region' => ['en_us', 'en-US'],
+            'normalizes mixed separators and duplicate dashes' => ['nl__nl', 'nl-NL'],
+            'supports script casing' => ['zh_hant_tw', 'zh-Hant-TW'],
+            'normalizes uppercase script to title case' => ['zh_HANT_tw', 'zh-Hant-TW'],
+            'supports numeric region' => ['es-419', 'es-419'],
+            'keeps variant lowercase' => ['sl-rozaj-biske', 'sl-rozaj-biske'],
+            'normalizes uppercase variant to lowercase' => ['en-POSIX', 'en-posix'],
+            'skips empty middle segments' => ['de--DE', 'de-DE'],
+            'handles leading separator segment' => ['-en', '-EN'],
+            'blank stays blank' => ['   ', ''],
+        ];
+    }
+
+    #[DataProvider('normalizeProvider')]
+    public function testNormalize(string $locale, string $expected): void
+    {
+        self::assertSame($expected, LocaleNormalizer::normalize($locale));
+    }
+
+    public function testNormalizeOrDefaultUsesNormalizedInputWhenPresent(): void
+    {
+        self::assertSame('fr-FR', LocaleNormalizer::normalizeOrDefault(' FR_fr ', 'en'));
+    }
+
+    public function testNormalizeOrDefaultUsesNormalizedDefaultWhenInputBlank(): void
+    {
+        self::assertSame('pt-BR', LocaleNormalizer::normalizeOrDefault('   ', ' PT_br '));
+    }
+
+    public function testNormalizeOrDefaultFallsBackToEnglishWhenBothBlank(): void
+    {
+        self::assertSame('en', LocaleNormalizer::normalizeOrDefault('   ', '   '));
+    }
+
+    public function testNormalizeRequiredReturnsCanonicalLocale(): void
+    {
+        self::assertSame('nl-NL', LocaleNormalizer::normalizeRequired('nl_nl'));
+    }
+
+    public function testNormalizeRequiredThrowsForBlankLocale(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('locale cannot be empty.');
+
+        LocaleNormalizer::normalizeRequired('  ');
+    }
+
+    public function testNormalizeRequiredThrowsUsingCustomFieldName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('preferredLocale cannot be empty.');
+
+        LocaleNormalizer::normalizeRequired('  ', 'preferredLocale');
+    }
+}


### PR DESCRIPTION
## Summary
- Add a shared `LocaleNormalizer` to canonicalize locale aliases (e.g. `en_US`, `EN-us`) into stable BCP-47 style values.
- Route locale handling in `HumanizerConfig` and `IntlFormatterBridge` through this normalizer so runtime formatting and stored config behave consistently.
- Expand formatter/config/normalizer tests to lock alias behavior and keep strict quality gates green.

## Test plan
- [x] `vendor/bin/phpunit --coverage-text` (100% lines/classes/methods)
- [x] `vendor/bin/infection --threads=max` (all mutants caught, MSI/covered MSI satisfy 100% thresholds)
- [x] `vendor/bin/phpcs --standard=PSR12 src tests`
- [x] `vendor/bin/phpstan analyse -c phpstan.neon`
- [x] `vendor/bin/phpunit`
- [x] `grumphp` hooks pass during commit (`phpcs`, `phpstan`, `phpunit`)